### PR TITLE
Fix RemoteTask equality

### DIFF
--- a/Machine.Specifications.ReSharper.Runner.9.1/Tasks/Task.cs
+++ b/Machine.Specifications.ReSharper.Runner.9.1/Tasks/Task.cs
@@ -43,7 +43,7 @@ namespace Machine.Specifications.ReSharperRunner.Tasks
 
         public override bool Equals(RemoteTask other)
         {
-            return Equals(other as Task);
+            return Equals(other as object);
         }
 
         public override bool Equals(object other)


### PR DESCRIPTION
Hi!
Consider the following code:
```csharp
RemoteTask t1 = new RunAssemblyTask(...);
RemoteTask t2 = new ContextTask(...);
```
And t1.Equals(t2) can return true. 

This is the reason of [DCVR-6932](https://youtrack.jetbrains.com/issue/DCVR-6932)