### PR TITLE
Fix for NullReferenceException in Presentation.Element

### DIFF
--- a/Machine.Specifications.ReSharper.Provider.9.2/Presentation/Element.cs
+++ b/Machine.Specifications.ReSharper.Provider.9.2/Presentation/Element.cs
@@ -147,6 +147,11 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
 
         public bool Equals(IUnitTestElement other)
         {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
             if (ReferenceEquals(this, other))
             {
                 return true;

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,7 @@
 Machine.Specifications.Runner.Resharper 1.2.0
 -----------------------------
 - ReSharper 9.2 support (only)
+- Fixed NullReferenceException in Presentation.Element during test run (issue #20)
 
 Machine.Specifications.Runner.Resharper 1.1.0
 -----------------------------


### PR DESCRIPTION
Added null-check in Presentation.Element.Equals() method (Fixes #20)