### PR TITLE
Update for ReSharper 2017.1. Fixes #52

### DIFF
--- a/Machine.Specifications.ReSharper.Provider.10/Explorers/AssemblyExplorer.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Explorers/AssemblyExplorer.cs
@@ -2,10 +2,10 @@ using Machine.Specifications.ReSharperProvider.Presentation;
 
 namespace Machine.Specifications.ReSharperProvider.Explorers
 {
+    using System.Linq;
     using JetBrains.Metadata.Reader.API;
     using JetBrains.ProjectModel;
     using JetBrains.ReSharper.UnitTestFramework;
-    using JetBrains.Util;
 
     using Machine.Specifications.ReSharperProvider.Factories;
 
@@ -31,19 +31,21 @@ namespace Machine.Specifications.ReSharperProvider.Explorers
             consumer.OnUnitTestElement(contextElement);
 
             metadataTypeInfo.GetSpecifications()
+                .ToList()
                 .ForEach(x =>
                 {
                     var contextSpecificationElement = this._factories.ContextSpecifications.CreateContextSpecification(consumer, contextElement, x);
                     consumer.OnUnitTestElement(contextSpecificationElement);
                 });
 
-            metadataTypeInfo.GetBehaviors().ForEach(x =>
+            metadataTypeInfo.GetBehaviors().ToList().ForEach(x =>
             {
                 var behaviorElement = this._factories.Behaviors.CreateBehavior(contextElement, x, consumer);
                 consumer.OnUnitTestElement(behaviorElement);
 
                 this._factories.BehaviorSpecifications
                             .CreateBehaviorSpecificationsFromBehavior(behaviorElement, x, consumer)
+                            .ToList()
                             .ForEach(consumer.OnUnitTestElement);
 
                 consumer.OnUnitTestElementChanged(behaviorElement);

--- a/Machine.Specifications.ReSharper.Provider.10/Explorers/MSpecTestElementsSource.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Explorers/MSpecTestElementsSource.cs
@@ -52,11 +52,6 @@ namespace Machine.Specifications.ReSharperProvider.Explorers
             observer.OnCompleted();
         }
         
-        public IUnitTestProvider Provider
-        {
-            get { return _provider; }
-        }
-
         private static bool IsProjectFile(IFile psiFile)
         {
             // Can return null for external sources

--- a/Machine.Specifications.ReSharper.Provider.10/Machine.Specifications.ReSharper.Provider.10.csproj
+++ b/Machine.Specifications.ReSharper.Provider.10/Machine.Specifications.ReSharper.Provider.10.csproj
@@ -42,16 +42,14 @@
       <HintPath>..\packages\Antlr2.Runtime.2.7.7.02\lib\antlr.runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Appccelerate.Fundamentals, Version=2.3.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.JetBrains.2.2.0.1\lib\net45\Appccelerate.Fundamentals.dll</HintPath>
+    </Reference>
+    <Reference Include="Appccelerate.StateMachine, Version=2.2.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.JetBrains.2.2.0.1\lib\net45\Appccelerate.StateMachine.dll</HintPath>
+    </Reference>
     <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
       <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CorApi, Version=1.0.0.12, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Win32.1.0.20161020.46\lib\net40\CorApi.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CorApi2, Version=1.0.0.13, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Win32.1.0.20161020.46\lib\net40\CorApi2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DevExpress.Data.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
@@ -86,33 +84,29 @@
       <HintPath>..\packages\ICSharpCode.NRefactory.5.5.1\lib\Net40\ICSharpCode.NRefactory.Xml.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6058.1576, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.JetBrains.Stripped.0.87.20160802.0\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6144.33521, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.JetBrains.Stripped.0.87.20161027.6\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Ionic.Zip.Reduced, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JetBrains.Annotations, Version=10.4.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.10.4.0\lib\net\JetBrains.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="JetBrains.MSBuild.Logger, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.MSBuild.Logger.1.0.20170130.0\lib\net\JetBrains.MSBuild.Logger.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="JetBrains.System.Reflection.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=4fea49dae943e013, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.System.Reflection.Metadata.1.0.0\lib\net45\JetBrains.System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Runner.Utility, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Machine.Specifications.Runner.Utility.0.9.0\lib\net45\Machine.Specifications.Runner.Utility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\Microsoft.Build.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\Microsoft.Build.Framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\Microsoft.Build.Utilities.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MahApps.Metro, Version=1.3.0.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.MahApps.Metro.1.3.1\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Deployment.Compression, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
@@ -171,121 +165,78 @@
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Debugger.Soft, Version=1.0.0.5, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugger.Soft.1.0.20161020.46\lib\net40\Mono.Debugger.Soft.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Debugging, Version=1.0.0.6, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.1.0.20161020.46\lib\net40\Mono.Debugging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Debugging.Soft, Version=1.0.0.6, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Soft.1.0.20161020.46\lib\net40\Mono.Debugging.Soft.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Debugging.Win32, Version=1.0.0.20, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Win32.1.0.20161020.46\lib\net40\Mono.Debugging.Win32.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Client, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Client.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Commands, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Commands.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Commands, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Configuration, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Configuration.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ContentModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.ContentModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ContentModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ContentModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.13.0.824, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Core.2.13.0\lib\net40-Client\NuGet.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Core.2.14.1\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.DependencyResolver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Frameworks.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.LibraryModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.LibraryModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.LibraryModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.PackageManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.PackageManagement, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.PackageManagement.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Packaging.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Packaging.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ProjectManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ProjectManagement.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ProjectManagement, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.ProjectManagement.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ProjectModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ProjectModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.ProjectModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.Types, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.Core.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.Core.v2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.v2.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.v2, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.Core.v2.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.Core.v3, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.v3.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.v3, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.Core.v3.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.VisualStudio, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.VisualStudio.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.VisualStudio, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.VisualStudio.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Repositories, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Repositories.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Repositories, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Repositories.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Resolver, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Resolver, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Resolver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.RuntimeModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.RuntimeModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.RuntimeModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.RuntimeModel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Versioning.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -303,9 +254,8 @@
       <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sprache, Version=2.0.0.0, Culture=neutral, PublicKeyToken=23dafc55df9bd3a3, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sprache.JetBrains.2.0.0.44\lib\portable-net4+netcore45+win8+wp8+sl5+MonoAndroid1+MonoTouch1\Sprache.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Sprache, Version=2.1.0.0, Culture=neutral, PublicKeyToken=f763bc865f9b2be9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sprache.JetBrains.2.1.0\lib\net40\Sprache.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Concurrent" />
@@ -320,22 +270,14 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Windows.Interactivity, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.System.Windows.Interactivity.2.0.20140318.0\lib\System.Windows.Interactivity.dll</HintPath>
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.System.Windows.Interactivity.3.0.40218\lib\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Vestris.ResourceLib, Version=1.4.33.0, Culture=neutral, PublicKeyToken=ec632d8ba5e5750d, processorArchitecture=MSIL">
       <HintPath>..\packages\Vestris.ResourceLib.JetBrains.1.4.20150303.0\lib\Net\Vestris.ResourceLib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="VSCodeDebugging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.VSCodeDebugging.1.0.20161019.44\lib\net45\VSCodeDebugging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
@@ -347,13 +289,8 @@
       <HintPath>..\packages\xunit.JetBrains.1.9.2\lib\net20\xunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.JetBrains.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.2.0.3239, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.runner.utility.JetBrains.2.2.0\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.runner.utility.net452, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.utility.2.2.0\lib\net452\xunit.runner.utility.net452.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -410,38 +347,38 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets'))" />
     <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets'))" />
   </Target>
   <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets" Condition="Exists('..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets" Condition="Exists('..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Machine.Specifications.ReSharper.Provider.10/Presentation/BehaviorElement.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Presentation/BehaviorElement.cs
@@ -45,16 +45,16 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
             get { return "Behavior"; }
         }
 
-        public override IEnumerable<UnitTestElementCategory> Categories
+        public override ISet<UnitTestElementCategory> OwnCategories
         {
             get
             {
                 if (this.Context == null)
                 {
-                    return UnitTestElementCategory.Uncategorized;
+                    return UnitTestElementCategory.Uncategorized.ToSet();
                 }
 
-                return this.Context.Categories;
+                return this.Context.OwnCategories;
             }
         }
 

--- a/Machine.Specifications.ReSharper.Provider.10/Presentation/BehaviorSpecificationElement.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Presentation/BehaviorSpecificationElement.cs
@@ -43,16 +43,16 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
             get { return "Behavior Specification"; }
         }
 
-        public override IEnumerable<UnitTestElementCategory> Categories
+        public override ISet<UnitTestElementCategory> OwnCategories
         {
             get
             {
                 if (this.Behavior == null)
                 {
-                    return UnitTestElementCategory.Uncategorized;
+                    return UnitTestElementCategory.Uncategorized.ToSet();
                 }
 
-                return this.Behavior.Categories;
+                return this.Behavior.OwnCategories;
             }
         }
 

--- a/Machine.Specifications.ReSharper.Provider.10/Presentation/ContextElement.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Presentation/ContextElement.cs
@@ -14,7 +14,7 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
 
     public class ContextElement : Element
     {
-        readonly IEnumerable<UnitTestElementCategory> _categories;
+        readonly ISet<UnitTestElementCategory> _categories;
         readonly UnitTestElementId _id;
         readonly string _subject;
 
@@ -52,7 +52,7 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
             get { return "Context"; }
         }
 
-        public override IEnumerable<UnitTestElementCategory> Categories
+        public override ISet<UnitTestElementCategory> OwnCategories
         {
             get { return this._categories; }
         }

--- a/Machine.Specifications.ReSharper.Provider.10/Presentation/ContextSpecificationElement.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Presentation/ContextSpecificationElement.cs
@@ -42,16 +42,16 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
             get { return "Specification"; }
         }
 
-        public override IEnumerable<UnitTestElementCategory> Categories
+        public override ISet<UnitTestElementCategory> OwnCategories
         {
             get
             {
                 if (this.Context == null)
                 {
-                    return UnitTestElementCategory.Uncategorized;
+                    return UnitTestElementCategory.Uncategorized.ToSet();
                 }
 
-                return this.Context.Categories;
+                return this.Context.OwnCategories;
             }
         }
 

--- a/Machine.Specifications.ReSharper.Provider.10/Presentation/Element.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/Presentation/Element.cs
@@ -57,7 +57,7 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
         }
 
         public abstract string Kind { get; }
-        public abstract IEnumerable<UnitTestElementCategory> Categories { get; }
+        public abstract ISet<UnitTestElementCategory> OwnCategories { get; }
         public string ExplicitReason { get; private set; }
 
         public abstract UnitTestElementId Id
@@ -277,7 +277,7 @@ namespace Machine.Specifications.ReSharperProvider.Presentation
         public virtual IEnumerable<UnitTestElementLocation> GetLocations(IDeclaredElement element)
         {
             var locations = new List<UnitTestElementLocation>();
-            element.GetDeclarations().ForEach(declaration =>
+            element.GetDeclarations().ToList().ForEach(declaration =>
             {
                 IFile file = declaration.GetContainingFile();
                 if (file != null)

--- a/Machine.Specifications.ReSharper.Provider.10/PsiExtensions.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/PsiExtensions.cs
@@ -265,7 +265,7 @@ namespace Machine.Specifications.ReSharperProvider
             finder.FindInheritors(clazz,
                                   searchDomain,
                                   findResult.Consumer,
-                                  NullProgressIndicator.Instance);
+                                  NullProgressIndicator.Create());
 
             return findResult.Found;
         }

--- a/Machine.Specifications.ReSharper.Provider.10/app.config
+++ b/Machine.Specifications.ReSharper.Provider.10/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-0.9.6.0" newVersion="0.9.6.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Windows.Interactivity" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Machine.Specifications.ReSharper.Provider.10/packages.config
+++ b/Machine.Specifications.ReSharper.Provider.10/packages.config
@@ -2,34 +2,39 @@
 <packages>
   <package id="Antlr2.Runtime" version="2.7.7.02" targetFramework="net46" />
   <package id="Antlr2.Tools" version="2.7.6.4" targetFramework="net46" />
+  <package id="Appccelerate.StateMachine.JetBrains" version="2.2.0.1" targetFramework="net46" />
   <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net46" />
   <package id="ICSharpCode.NRefactory" version="5.5.1" targetFramework="net46" />
-  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net46" />
+  <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net46" />
   <package id="JetBrains.Build.Platform.Tasks.ThemedIconsPacker" version="2.0.20151217.1" targetFramework="net46" developmentDependency="true" />
-  <package id="JetBrains.ExternalAnnotations" version="10.2.5" targetFramework="net46" />
-  <package id="JetBrains.MSBuild.Xplat.Engine" version="20161013.1.0" targetFramework="net46" />
-  <package id="JetBrains.NuGet.Core" version="2.13.0" targetFramework="net46" />
-  <package id="JetBrains.NuGet.Ultimate" version="3.5.0.1" targetFramework="net46" />
-  <package id="JetBrains.Platform.Core.Ide" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Core.Shell" version="107.0.20161214.153252" targetFramework="net46" />
-  <package id="JetBrains.Platform.Core.Text" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="107.0.20161214.153643" targetFramework="net46" />
+  <package id="JetBrains.ExternalAnnotations" version="10.2.18" targetFramework="net46" />
+  <package id="JetBrains.MahApps.Metro" version="1.3.1" targetFramework="net46" />
+  <package id="JetBrains.NuGet.Core" version="2.14.1" targetFramework="net46" />
+  <package id="JetBrains.NuGet.Frameworks" version="4.0.0" targetFramework="net46" />
+  <package id="JetBrains.NuGet.Ultimate" version="4.0.0" targetFramework="net46" />
+  <package id="JetBrains.NuGet.Versioning" version="4.0.0" targetFramework="net46" />
+  <package id="JetBrains.Platform.Core.Ide" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Platform.Core.Shell" version="108.0.20170402.74924" targetFramework="net46" />
+  <package id="JetBrains.Platform.Core.Text" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="108.0.20170402.75356" targetFramework="net46" />
   <package id="JetBrains.Platform.Lib.DevExpress" version="2.0.20150224.0" targetFramework="net46" />
   <package id="JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab" version="2.0.20140304.0" targetFramework="net46" />
-  <package id="JetBrains.Platform.Lib.System.Windows.Interactivity" version="2.0.20140318.0" targetFramework="net46" />
+  <package id="JetBrains.Platform.Lib.System.Windows.Interactivity" version="3.0.40218" targetFramework="net46" />
   <package id="JetBrains.Platform.Lib.WpfContrib" version="2.0.20150225.0" targetFramework="net46" />
-  <package id="JetBrains.Platform.RdProtocol" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Symbols" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Tests.Framework" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.Core" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.src" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.Tasks" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.test.Framework" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.UnitTesting" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.ReSharper.SDK" version="2016.3.20161215.134837" targetFramework="net46" developmentDependency="true" />
-  <package id="JetBrains.ReSharper.SDK.Internal" version="107.0.20161215.134837" targetFramework="net46" />
+  <package id="JetBrains.Platform.MSBuild.Logger" version="1.0.20170130.0" targetFramework="net46" developmentDependency="true" />
+  <package id="JetBrains.Platform.RdProtocol" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Platform.Symbols" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Platform.Tests.Framework" version="108.0.20170402.75356" targetFramework="net46" />
+  <package id="JetBrains.Psi.Features.Core" version="108.0.20170403.124150" targetFramework="net46" />
+  <package id="JetBrains.Psi.Features.src" version="108.0.20170403.124150" targetFramework="net46" />
+  <package id="JetBrains.Psi.Features.Tasks" version="108.0.20170403.124150" targetFramework="net46" />
+  <package id="JetBrains.Psi.Features.test.Framework" version="108.0.20170403.124150" targetFramework="net46" />
+  <package id="JetBrains.Psi.Features.UnitTesting" version="108.0.20170403.124150" targetFramework="net46" />
+  <package id="JetBrains.ReSharper.SDK" version="2017.1.20170403.131543" targetFramework="net46" developmentDependency="true" />
+  <package id="JetBrains.ReSharper.SDK.Internal" version="108.0.20170403.131543" targetFramework="net46" />
+  <package id="JetBrains.System.Reflection.Metadata" version="1.0.0" targetFramework="net46" />
   <package id="Machine.Specifications.Runner.Utility" version="0.9.0" targetFramework="net46" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net46" />
   <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net46" />
@@ -38,11 +43,6 @@
   <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net46" />
-  <package id="Mono.Debugger.Soft" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.Debugging" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.Debugging.Soft" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.Debugging.Win32" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.VSCodeDebugging" version="1.0.20161019.44" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46" />
   <package id="NUnit" version="2.6.4" targetFramework="net46" />
   <package id="NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net46" />
@@ -50,13 +50,13 @@
   <package id="NVelocity" version="1.0.3" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="sharpcompress" version="0.11.6" targetFramework="net46" />
-  <package id="SharpZipLib.JetBrains.Stripped" version="0.87.20160802.0" targetFramework="net46" />
-  <package id="Sprache.JetBrains" version="2.0.0.44" targetFramework="net46" />
+  <package id="SharpZipLib.JetBrains.Stripped" version="0.87.20161027.6" targetFramework="net46" />
+  <package id="Sprache.JetBrains" version="2.1.0" targetFramework="net46" />
   <package id="Vestris.ResourceLib.JetBrains" version="1.4.20150303.0" targetFramework="net46" />
-  <package id="Wave" version="7.0.0.0" targetFramework="net46" />
+  <package id="Wave" version="8.0.0.0" targetFramework="net46" />
   <package id="Windows7APICodePack.JetBrains.Stripped" version="1.1.20150225.0" targetFramework="net46" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net46" />
-  <package id="xunit.abstractions.JetBrains" version="2.0.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
   <package id="xunit.JetBrains" version="1.9.2" targetFramework="net46" />
-  <package id="xunit.runner.utility.JetBrains" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.runner.utility" version="2.2.0" targetFramework="net46" />
 </packages>

--- a/Machine.Specifications.ReSharper.Runner.10/Machine.Specifications.ReSharper.Runner.10.csproj
+++ b/Machine.Specifications.ReSharper.Runner.10/Machine.Specifications.ReSharper.Runner.10.csproj
@@ -42,16 +42,14 @@
       <HintPath>..\packages\Antlr2.Runtime.2.7.7.02\lib\antlr.runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Appccelerate.Fundamentals, Version=2.3.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.JetBrains.2.2.0.1\lib\net45\Appccelerate.Fundamentals.dll</HintPath>
+    </Reference>
+    <Reference Include="Appccelerate.StateMachine, Version=2.2.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.JetBrains.2.2.0.1\lib\net45\Appccelerate.StateMachine.dll</HintPath>
+    </Reference>
     <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
       <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CorApi, Version=1.0.0.12, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Win32.1.0.20161020.46\lib\net40\CorApi.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CorApi2, Version=1.0.0.13, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Win32.1.0.20161020.46\lib\net40\CorApi2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DevExpress.Data.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
@@ -86,33 +84,29 @@
       <HintPath>..\packages\ICSharpCode.NRefactory.5.5.1\lib\Net40\ICSharpCode.NRefactory.Xml.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6058.1576, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.JetBrains.Stripped.0.87.20160802.0\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6144.33521, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.JetBrains.Stripped.0.87.20161027.6\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Ionic.Zip.Reduced, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JetBrains.Annotations, Version=10.4.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.10.4.0\lib\net\JetBrains.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="JetBrains.MSBuild.Logger, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.MSBuild.Logger.1.0.20170130.0\lib\net\JetBrains.MSBuild.Logger.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="JetBrains.System.Reflection.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=4fea49dae943e013, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.System.Reflection.Metadata.1.0.0\lib\net45\JetBrains.System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Runner.Utility, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Machine.Specifications.Runner.Utility.0.9.0\lib\net45\Machine.Specifications.Runner.Utility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\Microsoft.Build.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\Microsoft.Build.Framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\Microsoft.Build.Utilities.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MahApps.Metro, Version=1.3.0.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.MahApps.Metro.1.3.1\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Deployment.Compression, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
@@ -171,121 +165,78 @@
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Debugger.Soft, Version=1.0.0.5, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugger.Soft.1.0.20161020.46\lib\net40\Mono.Debugger.Soft.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Debugging, Version=1.0.0.6, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.1.0.20161020.46\lib\net40\Mono.Debugging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Debugging.Soft, Version=1.0.0.6, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Soft.1.0.20161020.46\lib\net40\Mono.Debugging.Soft.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Debugging.Win32, Version=1.0.0.20, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Debugging.Win32.1.0.20161020.46\lib\net40\Mono.Debugging.Win32.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Client, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Client.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Commands, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Commands.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Commands, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Configuration, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Configuration.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ContentModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.ContentModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ContentModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ContentModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.13.0.824, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Core.2.13.0\lib\net40-Client\NuGet.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Core.2.14.1\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.DependencyResolver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Frameworks.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.LibraryModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.LibraryModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.LibraryModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.PackageManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.PackageManagement, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.PackageManagement.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Packaging.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Packaging.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ProjectManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ProjectManagement.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ProjectManagement, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.ProjectManagement.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ProjectModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ProjectModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.ProjectModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.Types, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.Core.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.Core.v2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.v2.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.v2, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.Core.v2.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.Core.v3, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.v3.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.v3, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.Core.v3.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol.VisualStudio, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.VisualStudio.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.VisualStudio, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Protocol.VisualStudio.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Repositories, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Repositories.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Repositories, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Repositories.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Resolver, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Resolver, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Resolver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.RuntimeModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.RuntimeModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.RuntimeModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.RuntimeModel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.5.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.3.5.0.1\lib\net45\NuGet.Versioning.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -303,9 +254,8 @@
       <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sprache, Version=2.0.0.0, Culture=neutral, PublicKeyToken=23dafc55df9bd3a3, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sprache.JetBrains.2.0.0.44\lib\portable-net4+netcore45+win8+wp8+sl5+MonoAndroid1+MonoTouch1\Sprache.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Sprache, Version=2.1.0.0, Culture=neutral, PublicKeyToken=f763bc865f9b2be9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sprache.JetBrains.2.1.0\lib\net40\Sprache.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Concurrent" />
@@ -320,22 +270,14 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MSBuild.Xplat.Engine.20161013.1.0\lib\net45\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Windows.Interactivity, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.System.Windows.Interactivity.2.0.20140318.0\lib\System.Windows.Interactivity.dll</HintPath>
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.System.Windows.Interactivity.3.0.40218\lib\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Vestris.ResourceLib, Version=1.4.33.0, Culture=neutral, PublicKeyToken=ec632d8ba5e5750d, processorArchitecture=MSIL">
       <HintPath>..\packages\Vestris.ResourceLib.JetBrains.1.4.20150303.0\lib\Net\Vestris.ResourceLib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="VSCodeDebugging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5e9ce85b0923c84f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.VSCodeDebugging.1.0.20161019.44\lib\net45\VSCodeDebugging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
@@ -347,13 +289,8 @@
       <HintPath>..\packages\xunit.JetBrains.1.9.2\lib\net20\xunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.JetBrains.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.2.0.3239, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.runner.utility.JetBrains.2.2.0\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.runner.utility.net452, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.utility.2.2.0\lib\net452\xunit.runner.utility.net452.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -389,9 +326,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="Machine.Specifications.Runner.Resharper.10.nuspec">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="Machine.Specifications.ReSharper.Runner.10.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -402,38 +337,38 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets'))" />
     <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets'))" />
   </Target>
   <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.107.0.20161214.153252\build\JetBrains.Platform.Core.Shell.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.107.0.20161214.153643\build\JetBrains.Platform.Core.Text.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.107.0.20161214.153643\build\JetBrains.Platform.RdProtocol.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.107.0.20161214.153643\build\JetBrains.Platform.Core.Ide.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.107.0.20161214.153643\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets" Condition="Exists('..\packages\JetBrains.Platform.Symbols.107.0.20161214.153643\build\JetBrains.Platform.Symbols.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.107.0.20161214.153643\build\JetBrains.Platform.Tests.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.107.0.20161215.131222\build\JetBrains.Psi.Features.Tasks.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.107.0.20161215.131222\build\JetBrains.Psi.Features.Core.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.107.0.20161215.131222\build\JetBrains.Psi.Features.src.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.107.0.20161215.131222\build\JetBrains.Psi.Features.UnitTesting.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.107.0.20161215.131222\build\JetBrains.Psi.Features.test.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.107.0.20161215.134837\build\JetBrains.ReSharper.SDK.Internal.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets" Condition="Exists('..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Machine.Specifications.ReSharper.Runner.10/Machine.Specifications.ReSharper.Runner.10.nuspec
+++ b/Machine.Specifications.ReSharper.Runner.10/Machine.Specifications.ReSharper.Runner.10.nuspec
@@ -15,14 +15,14 @@
 		<iconUrl>http://github.com/machine/machine.specifications/raw/master/Misc/Machine.Specifications-128x128.png</iconUrl>
 		<tags>test unit testing context specification bdd tdd mspec runner resharper</tags>
 		<dependencies>
-			<dependency id="Wave" version="[7.0]" />
+			<dependency id="Wave" version="[8.0]" />
 		</dependencies>
 	</metadata>
 	<files>
 
-		<file src="..\Build\Machine.Specifications.ReSharper.Provider.10.dll" target="dotFiles" />
-		<file src="..\Build\Machine.Specifications.ReSharper.Runner.10.dll" target="dotFiles" />
-		<file src="..\Build\Machine.Specifications.Runner.Utility.dll" target="dotFiles" />
+		<file src="..\Build\Machine.Specifications.ReSharper.Provider.10.dll" target="lib\net46" />
+		<file src="..\Build\Machine.Specifications.ReSharper.Runner.10.dll" target="lib\net46" />
+		<file src="..\Build\Machine.Specifications.Runner.Utility.dll" target="lib\net46" />
 
 		<!-- Settings -->
 		<file src="..\Misc\*.dotSettings" target="dotFiles\Extensions\Machine.Specifications.Runner.Resharper9\settings" exclude="..\Misc\Resharper.Style.DotSettings;..\Misc\Resharper.TypeMemberLayout.DotSettings"/>

--- a/Machine.Specifications.ReSharper.Runner.10/packages.config
+++ b/Machine.Specifications.ReSharper.Runner.10/packages.config
@@ -1,62 +1,62 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr2.Runtime" version="2.7.7.02" targetFramework="net46" />
-  <package id="Antlr2.Tools" version="2.7.6.4" targetFramework="net46" />
-  <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net46" />
-  <package id="ICSharpCode.NRefactory" version="5.5.1" targetFramework="net46" />
-  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net46" />
+  <package id="Antlr2.Runtime" version="2.7.7.02" targetFramework="net46"  developmentDependency="true" />
+  <package id="Antlr2.Tools" version="2.7.6.4" targetFramework="net46"  developmentDependency="true" />
+  <package id="Appccelerate.StateMachine.JetBrains" version="2.2.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net46"  developmentDependency="true" />
+  <package id="ICSharpCode.NRefactory" version="5.5.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net46"  developmentDependency="true" />
   <package id="JetBrains.Build.Platform.Tasks.ThemedIconsPacker" version="2.0.20151217.1" targetFramework="net46" developmentDependency="true" />
-  <package id="JetBrains.ExternalAnnotations" version="10.2.5" targetFramework="net46" />
-  <package id="JetBrains.MSBuild.Xplat.Engine" version="20161013.1.0" targetFramework="net46" />
-  <package id="JetBrains.NuGet.Core" version="2.13.0" targetFramework="net46" />
-  <package id="JetBrains.NuGet.Ultimate" version="3.5.0.1" targetFramework="net46" />
-  <package id="JetBrains.Platform.Core.Ide" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Core.Shell" version="107.0.20161214.153252" targetFramework="net46" />
-  <package id="JetBrains.Platform.Core.Text" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Lib.DevExpress" version="2.0.20150224.0" targetFramework="net46" />
-  <package id="JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab" version="2.0.20140304.0" targetFramework="net46" />
-  <package id="JetBrains.Platform.Lib.System.Windows.Interactivity" version="2.0.20140318.0" targetFramework="net46" />
-  <package id="JetBrains.Platform.Lib.WpfContrib" version="2.0.20150225.0" targetFramework="net46" />
-  <package id="JetBrains.Platform.RdProtocol" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Symbols" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Platform.Tests.Framework" version="107.0.20161214.153643" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.Core" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.src" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.Tasks" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.test.Framework" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.Psi.Features.UnitTesting" version="107.0.20161215.131222" targetFramework="net46" />
-  <package id="JetBrains.ReSharper.SDK" version="2016.3.20161215.134837" targetFramework="net46" developmentDependency="true" />
-  <package id="JetBrains.ReSharper.SDK.Internal" version="107.0.20161215.134837" targetFramework="net46" />
-  <package id="Machine.Specifications.Runner.Utility" version="0.9.0" targetFramework="net46" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net46" />
-  <package id="Mono.Debugger.Soft" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.Debugging" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.Debugging.Soft" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.Debugging.Win32" version="1.0.20161020.46" targetFramework="net46" />
-  <package id="Mono.VSCodeDebugging" version="1.0.20161019.44" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46" />
-  <package id="NUnit" version="2.6.4" targetFramework="net46" />
-  <package id="NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net46" />
-  <package id="NUnit.ReSharperRunner3" version="3.0.12" targetFramework="net46" />
-  <package id="NVelocity" version="1.0.3" targetFramework="net46" />
-  <package id="Owin" version="1.0" targetFramework="net46" />
-  <package id="sharpcompress" version="0.11.6" targetFramework="net46" />
-  <package id="SharpZipLib.JetBrains.Stripped" version="0.87.20160802.0" targetFramework="net46" />
-  <package id="Sprache.JetBrains" version="2.0.0.44" targetFramework="net46" />
-  <package id="Vestris.ResourceLib.JetBrains" version="1.4.20150303.0" targetFramework="net46" />
-  <package id="Wave" version="7.0.0.0" targetFramework="net46" />
-  <package id="Windows7APICodePack.JetBrains.Stripped" version="1.1.20150225.0" targetFramework="net46" />
-  <package id="xmlrpcnet" version="2.5.0" targetFramework="net46" />
-  <package id="xunit.abstractions.JetBrains" version="2.0.0" targetFramework="net46" />
-  <package id="xunit.JetBrains" version="1.9.2" targetFramework="net46" />
-  <package id="xunit.runner.utility.JetBrains" version="2.2.0" targetFramework="net46" />
+  <package id="JetBrains.ExternalAnnotations" version="10.2.18" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.MahApps.Metro" version="1.3.1" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.NuGet.Core" version="2.14.1" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.NuGet.Frameworks" version="4.0.0" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.NuGet.Ultimate" version="4.0.0" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.NuGet.Versioning" version="4.0.0" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Core.Ide" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Core.Shell" version="108.0.20170402.74924" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Core.Text" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Lib.DevExpress" version="2.0.20150224.0" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab" version="2.0.20140304.0" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Lib.System.Windows.Interactivity" version="3.0.40218" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Lib.WpfContrib" version="2.0.20150225.0" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.MSBuild.Logger" version="1.0.20170130.0" targetFramework="net46" developmentDependency="true" />
+  <package id="JetBrains.Platform.RdProtocol" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Symbols" version="108.0.20170402.75356" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Platform.Tests.Framework" version="108.0.20170402.75356" targetFramework="net46" developmentDependency="true"/>
+  <package id="JetBrains.Psi.Features.Core" version="108.0.20170403.124150" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Psi.Features.src" version="108.0.20170403.124150" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Psi.Features.Tasks" version="108.0.20170403.124150" targetFramework="net46"  developmentDependency="true"/>
+  <package id="JetBrains.Psi.Features.test.Framework" version="108.0.20170403.124150" targetFramework="net46" developmentDependency="true"/>
+  <package id="JetBrains.Psi.Features.UnitTesting" version="108.0.20170403.124150" targetFramework="net46"  developmentDependency="true" />
+  <package id="JetBrains.ReSharper.SDK" version="2017.1.20170403.131543" targetFramework="net46" developmentDependency="true" />
+  <package id="JetBrains.ReSharper.SDK.Internal" version="108.0.20170403.131543" targetFramework="net46" developmentDependency="true" />
+  <package id="JetBrains.System.Reflection.Metadata" version="1.0.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="Machine.Specifications.Runner.Utility" version="0.9.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46"  developmentDependency="true" />
+  <package id="NUnit" version="2.6.4" targetFramework="net46"  developmentDependency="true" />
+  <package id="NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net46"  developmentDependency="true" />
+  <package id="NUnit.ReSharperRunner3" version="3.0.12" targetFramework="net46"  developmentDependency="true" />
+  <package id="NVelocity" version="1.0.3" targetFramework="net46"  developmentDependency="true" />
+  <package id="Owin" version="1.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="sharpcompress" version="0.11.6" targetFramework="net46"  developmentDependency="true" />
+  <package id="SharpZipLib.JetBrains.Stripped" version="0.87.20161027.6" targetFramework="net46"  developmentDependency="true" />
+  <package id="Sprache.JetBrains" version="2.1.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="Vestris.ResourceLib.JetBrains" version="1.4.20150303.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="Wave" version="8.0.0.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="Windows7APICodePack.JetBrains.Stripped" version="1.1.20150225.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="xmlrpcnet" version="2.5.0" targetFramework="net46"  developmentDependency="true" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net46"  developmentDependency="true" />
+  <package id="xunit.JetBrains" version="1.9.2" targetFramework="net46"  developmentDependency="true" />
+  <package id="xunit.runner.utility" version="2.2.0" targetFramework="net46"  developmentDependency="true" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
-  nuget_version: '1.7.0'
+  nuget_version: '1.8.0'
   nuget_prerelease: false
-  assembly_version: '1.7.0'
+  assembly_version: '1.8.0'
 
 version: '$(nuget_version)+{build}'
 configuration: Release


### PR DESCRIPTION
Update for ReSharper 2017.1.  Besides having to rename one property and cleaning up some warnings - no logic changes. 

Fixes #52