### PR TITLE
 [Bug] Fix PSI detection of behaviors

### DIFF
--- a/Machine.Specifications.ReSharper.Provider.10/MspecPsiFileExplorer.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/MspecPsiFileExplorer.cs
@@ -99,13 +99,12 @@ namespace Machine.Specifications.ReSharperProvider
         {
             var solution = element.GetSolution();
 
+            var finder = solution.GetPsiServices().Finder;
             var searchDomain = _searchDomainFactory.CreateSearchDomain(solution, false);
             var consumer = new SearchResultsConsumer();
             var progress = NullProgressIndicator.Create();
 
-            solution.GetPsiServices()
-                .Finder
-                .Find(new[] {element}, searchDomain, consumer, SearchPattern.FIND_USAGES, progress);
+            finder.Find(new[] {element}, searchDomain, consumer, SearchPattern.FIND_USAGES, progress);
 
             var contexts = consumer.GetOccurrences()
                 .OfType<ReferenceOccurrence>()

--- a/Machine.Specifications.ReSharper.Provider.10/MspecTestElementMapper.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/MspecTestElementMapper.cs
@@ -43,16 +43,16 @@ namespace Machine.Specifications.ReSharperProvider
 
                 var type = new ClrTypeName(typeName);
 
-                var context = _factory.GetOrCreateContext(type, assemblyPath, subject, tags.ToArray(), false);
+                var context = _factory.GetOrCreateContext(_project, type, assemblyPath, subject, tags.ToArray(), false);
 
                 if (!string.IsNullOrEmpty(behaviorField) && !string.IsNullOrEmpty(behaviorType))
                 {
-                    var behavior = _factory.GetOrCreateBehavior(context, type, behaviorField, false);
+                    var behavior = _factory.GetOrCreateBehavior(_project, context, type, behaviorField, false);
 
-                    return _factory.GetOrCreateBehaviorSpecification(behavior, new ClrTypeName(behaviorType), fieldName, false);
+                    return _factory.GetOrCreateBehaviorSpecification(_project, behavior, new ClrTypeName(behaviorType), fieldName, false);
                 }
 
-                return _factory.GetOrCreateContextSpecification(context, type, fieldName, false);
+                return _factory.GetOrCreateContextSpecification(_project, context, type, fieldName, false);
             }
         }
 

--- a/Machine.Specifications.ReSharper.Provider.10/MspecTestElementMapperFactory.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/MspecTestElementMapperFactory.cs
@@ -17,7 +17,7 @@ namespace Machine.Specifications.ReSharperProvider
 
         private MspecTestElementMapper Create(IProject project, TargetFrameworkId targetFrameworkId)
         {
-            var factory = new UnitTestElementFactory(_serviceProvider, project, targetFrameworkId);
+            var factory = new UnitTestElementFactory(_serviceProvider, targetFrameworkId);
 
             return new MspecTestElementMapper(project, targetFrameworkId, factory);
         }

--- a/Machine.Specifications.ReSharper.Provider.10/MspecTestElementsSource.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/MspecTestElementsSource.cs
@@ -5,6 +5,7 @@ using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Assemblies.AssemblyToAssemblyResolvers;
 using JetBrains.ProjectModel.Assemblies.Impl;
 using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Search;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.UnitTestFramework;
 using JetBrains.ReSharper.UnitTestFramework.Exploration;
@@ -15,11 +16,13 @@ namespace Machine.Specifications.ReSharperProvider
     [SolutionComponent]
     public class MspecTestElementsSource : UnitTestExplorerFrom.DotNetArtefacts, IUnitTestExplorerFromFile
     {
+        private readonly SearchDomainFactory _searchDomainFactory;
         private readonly MspecServiceProvider _serviceProvider;
         private readonly ILogger _logger;
 
         public MspecTestElementsSource(
             MspecTestProvider provider,
+            SearchDomainFactory searchDomainFactory,
             ISolution solution,
             AssemblyToAssemblyReferencesResolveManager resolveManager,
             ResolveContextManager contextManager,
@@ -27,6 +30,7 @@ namespace Machine.Specifications.ReSharperProvider
             ILogger logger)
             : base(solution, provider, resolveManager, contextManager, logger)
         {
+            _searchDomainFactory = searchDomainFactory;
             _serviceProvider = serviceProvider;
             _logger = logger;
         }
@@ -55,7 +59,7 @@ namespace Machine.Specifications.ReSharperProvider
         public void ProcessFile(IFile psiFile, IUnitTestElementsObserver observer, Func<bool> interrupted)
         {
             var factory = new UnitTestElementFactory(_serviceProvider, psiFile.GetProject(), observer.TargetFrameworkId);
-            var explorer = new MspecPsiFileExplorer(factory, psiFile, observer, interrupted);
+            var explorer = new MspecPsiFileExplorer(_searchDomainFactory, factory, observer, interrupted);
 
             psiFile.ProcessDescendants(explorer);
 

--- a/Machine.Specifications.ReSharper.Provider.10/MspecTestElementsSource.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/MspecTestElementsSource.cs
@@ -47,18 +47,18 @@ namespace Machine.Specifications.ReSharperProvider
             IUnitTestElementsObserver observer, 
             CancellationToken token)
         {
-            var factory = new UnitTestElementFactory(_serviceProvider, project, observer.TargetFrameworkId);
+            var factory = new UnitTestElementFactory(_serviceProvider, observer.TargetFrameworkId);
             var explorer = new MspecTestMetadataExplorer(factory, observer);
 
             MetadataElementsSource.ExploreProject(project, assemblyPath, loader, observer, _logger, token,
-                assembly => explorer.ExploreAssembly(assembly, token));
+                assembly => explorer.ExploreAssembly(project, assembly, token));
 
             observer.OnCompleted();
         }
 
         public void ProcessFile(IFile psiFile, IUnitTestElementsObserver observer, Func<bool> interrupted)
         {
-            var factory = new UnitTestElementFactory(_serviceProvider, psiFile.GetProject(), observer.TargetFrameworkId);
+            var factory = new UnitTestElementFactory(_serviceProvider, observer.TargetFrameworkId);
             var explorer = new MspecPsiFileExplorer(_searchDomainFactory, factory, observer, interrupted);
 
             psiFile.ProcessDescendants(explorer);

--- a/Machine.Specifications.ReSharper.Provider.10/UnitTestElementFactory.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/UnitTestElementFactory.cs
@@ -93,10 +93,7 @@ namespace Machine.Specifications.ReSharperProvider
         {
             var elementId = _serviceProvider.CreateId(project, _targetFrameworkId, id);
 
-            var element = GetElementById<T>(elementId);
-
-            if (element == null)
-                element = factory(elementId);
+            var element = GetElementById<T>(elementId) ?? factory(elementId);
 
             var invalidChildren = element.Children.Where(x => x.State == UnitTestElementState.Invalid);
             _serviceProvider.ElementManager.RemoveElements(invalidChildren.ToSet());

--- a/Machine.Specifications.ReSharper.Provider.10/UnitTestElementFactory.cs
+++ b/Machine.Specifications.ReSharper.Provider.10/UnitTestElementFactory.cs
@@ -15,6 +15,8 @@ namespace Machine.Specifications.ReSharperProvider
         private readonly IProject _project;
         private readonly TargetFrameworkId _targetFrameworkId;
 
+        private readonly Dictionary<UnitTestElementId, IUnitTestElement> _elements = new Dictionary<UnitTestElementId, IUnitTestElement>();
+
         public UnitTestElementFactory(MspecServiceProvider serviceProvider, IProject project, TargetFrameworkId targetFrameworkId)
         {
             _serviceProvider = serviceProvider;
@@ -78,6 +80,9 @@ namespace Machine.Specifications.ReSharperProvider
         private T GetElementById<T>(UnitTestElementId id)
             where T : Element
         {
+            if (_elements.TryGetValue(id, out var element))
+                return element as T;
+
             return _serviceProvider.ElementManager.GetElementById(id) as T;
         }
 
@@ -93,6 +98,8 @@ namespace Machine.Specifications.ReSharperProvider
 
             element.Parent = parent;
             element.OwnCategories = categories;
+
+            _elements[elementId] = element;
 
             return element;
         }

--- a/Machine.Specifications.ReSharper.Tests/Elements/UnitTestElementFactoryTests.cs
+++ b/Machine.Specifications.ReSharper.Tests/Elements/UnitTestElementFactoryTests.cs
@@ -17,9 +17,9 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
-                var element = factory.GetOrCreateContext(new ClrTypeName("MyClass"), BaseTestDataPath, "subject",
+                var element = factory.GetOrCreateContext(project, new ClrTypeName("MyClass"), BaseTestDataPath, "subject",
                     new[] {"tag1"}, false);
 
                 Assert.That(element, Is.Not.Null);
@@ -33,14 +33,14 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
-                var element1 = factory.GetOrCreateContext(new ClrTypeName("MyClass"), BaseTestDataPath, "subject",
+                var element1 = factory.GetOrCreateContext(project, new ClrTypeName("MyClass"), BaseTestDataPath, "subject",
                     new[] { "tag1" }, false);
 
                 ServiceProvider.ElementManager.AddElements(new HashSet<IUnitTestElement> {element1});
 
-                var element2 = factory.GetOrCreateContext(new ClrTypeName("MyClass"), BaseTestDataPath, "subject",
+                var element2 = factory.GetOrCreateContext(project, new ClrTypeName("MyClass"), BaseTestDataPath, "subject",
                     new[] { "tag1" }, false);
 
                 Assert.That(element1, Is.Not.Null);
@@ -54,10 +54,10 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
                 var parent = Substitute.For<IUnitTestElement>();
-                var element = factory.GetOrCreateContextSpecification(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var element = factory.GetOrCreateContextSpecification(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 Assert.That(element, Is.Not.Null);
                 Assert.That(element.GetPresentation(), Is.EqualTo("my field"));
@@ -69,14 +69,14 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
-                var parent = factory.GetOrCreateContext(new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
-                var element1 = factory.GetOrCreateContextSpecification(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var parent = factory.GetOrCreateContext(project, new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
+                var element1 = factory.GetOrCreateContextSpecification(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 ServiceProvider.ElementManager.AddElements(new HashSet<IUnitTestElement> {element1});
 
-                var element2 = factory.GetOrCreateContextSpecification(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var element2 = factory.GetOrCreateContextSpecification(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 Assert.That(element1, Is.Not.Null);
                 Assert.That(element2, Is.Not.Null);
@@ -89,10 +89,10 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
                 var parent = Substitute.For<IUnitTestElement>();
-                var element = factory.GetOrCreateBehavior(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var element = factory.GetOrCreateBehavior(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 Assert.That(element, Is.Not.Null);
                 Assert.That(element.GetPresentation(), Is.EqualTo("behaves like my field"));
@@ -104,14 +104,14 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
-                var parent = factory.GetOrCreateContext(new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
-                var element1 = factory.GetOrCreateBehavior(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var parent = factory.GetOrCreateContext(project, new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
+                var element1 = factory.GetOrCreateBehavior(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 ServiceProvider.ElementManager.AddElements(new HashSet<IUnitTestElement> { element1 });
 
-                var element2 = factory.GetOrCreateBehavior(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var element2 = factory.GetOrCreateBehavior(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 Assert.That(element1, Is.Not.Null);
                 Assert.That(element2, Is.Not.Null);
@@ -124,10 +124,10 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
-                var parent = factory.GetOrCreateContext(new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
-                var element = factory.GetOrCreateBehaviorSpecification(parent, new ClrTypeName("MyClass"), "my_field", false);
+                var parent = factory.GetOrCreateContext(project, new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
+                var element = factory.GetOrCreateBehaviorSpecification(project, parent, new ClrTypeName("MyClass"), "my_field", false);
 
                 Assert.That(element, Is.Not.Null);
                 Assert.That(element.GetPresentation(), Is.EqualTo("my field"));
@@ -139,15 +139,15 @@ namespace Machine.Specifications.ReSharper.Tests.Elements
         {
             With(project =>
             {
-                var factory = new UnitTestElementFactory(ServiceProvider, project, TargetFrameworkId.Default);
+                var factory = new UnitTestElementFactory(ServiceProvider, TargetFrameworkId.Default);
 
-                var context = factory.GetOrCreateContext(new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
-                var behavior = factory.GetOrCreateBehavior(context, new ClrTypeName("MyClass"), "my_field", false);
-                var element1 = factory.GetOrCreateBehaviorSpecification(behavior, new ClrTypeName("MyClass"), "my_field", false);
+                var context = factory.GetOrCreateContext(project, new ClrTypeName("Parent"), BaseTestDataPath, "subject", new string[0], false);
+                var behavior = factory.GetOrCreateBehavior(project, context, new ClrTypeName("MyClass"), "my_field", false);
+                var element1 = factory.GetOrCreateBehaviorSpecification(project, behavior, new ClrTypeName("MyClass"), "my_field", false);
 
                 ServiceProvider.ElementManager.AddElements(new HashSet<IUnitTestElement> { element1 });
 
-                var element2 = factory.GetOrCreateBehaviorSpecification(behavior, new ClrTypeName("MyClass"), "my_field", false);
+                var element2 = factory.GetOrCreateBehaviorSpecification(project, behavior, new ClrTypeName("MyClass"), "my_field", false);
 
                 Assert.That(element1, Is.Not.Null);
                 Assert.That(element2, Is.Not.Null);

--- a/Machine.Specifications.ReSharper.Tests/ReflectionWithSingleProject.cs
+++ b/Machine.Specifications.ReSharper.Tests/ReflectionWithSingleProject.cs
@@ -8,6 +8,7 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.FeaturesTestFramework.UnitTesting;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.Search;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.TestFramework;
 using JetBrains.ReSharper.UnitTestFramework;
@@ -148,10 +149,11 @@ namespace Machine.Specifications.ReSharper.Tests
         private TestUnitTestElementObserver GetPsiObserver(IFile file, IProject project)
         {
             var serviceProvider = Solution.GetComponent<MspecServiceProvider>();
+            var searchDomainFactory = Solution.GetComponent<SearchDomainFactory>();
             var observer = new TestUnitTestElementObserver();
             var factory = new UnitTestElementFactory(serviceProvider, project, observer.TargetFrameworkId);
 
-            var explorer = new MspecPsiFileExplorer(factory, file, observer, () => false);
+            var explorer = new MspecPsiFileExplorer(searchDomainFactory, factory, observer, () => false);
             file.ProcessDescendants(explorer);
 
             return observer;

--- a/Machine.Specifications.ReSharper.Tests/ReflectionWithSingleProject.cs
+++ b/Machine.Specifications.ReSharper.Tests/ReflectionWithSingleProject.cs
@@ -64,8 +64,8 @@ namespace Machine.Specifications.ReSharper.Tests
         {
             Run(filename, (project, file, assembly) =>
             {
-                var psiObserver = GetPsiObserver(file, project);
-                var metadataObserver = GetMetadataObserver(assembly, project);
+                var psiObserver = GetPsiObserver(file);
+                var metadataObserver = GetMetadataObserver(project, assembly);
 
                 action(psiObserver);
                 action(metadataObserver);
@@ -134,24 +134,24 @@ namespace Machine.Specifications.ReSharper.Tests
                 .GetTheOnlyPsiFile<CSharpLanguage>();
         }
 
-        private TestUnitTestElementObserver GetMetadataObserver(IMetadataAssembly assembly, IProject project)
+        private TestUnitTestElementObserver GetMetadataObserver(IProject project, IMetadataAssembly assembly)
         {
             var serviceProvider = Solution.GetComponent<MspecServiceProvider>();
             var observer = new TestUnitTestElementObserver();
-            var factory = new UnitTestElementFactory(serviceProvider, project, observer.TargetFrameworkId);
+            var factory = new UnitTestElementFactory(serviceProvider, observer.TargetFrameworkId);
 
             var explorer = new MspecTestMetadataExplorer(factory, observer);
-            explorer.ExploreAssembly(assembly, CancellationToken.None);
+            explorer.ExploreAssembly(project, assembly, CancellationToken.None);
 
             return observer;
         }
 
-        private TestUnitTestElementObserver GetPsiObserver(IFile file, IProject project)
+        private TestUnitTestElementObserver GetPsiObserver(IFile file)
         {
             var serviceProvider = Solution.GetComponent<MspecServiceProvider>();
             var searchDomainFactory = Solution.GetComponent<SearchDomainFactory>();
             var observer = new TestUnitTestElementObserver();
-            var factory = new UnitTestElementFactory(serviceProvider, project, observer.TargetFrameworkId);
+            var factory = new UnitTestElementFactory(serviceProvider, observer.TargetFrameworkId);
 
             var explorer = new MspecPsiFileExplorer(searchDomainFactory, factory, observer, () => false);
             file.ProcessDescendants(explorer);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Visual Studio 2017
 
 environment:
-  nuget_version: '2.0.0'
+  nuget_version: '2.0.1'
   nuget_prerelease: false
-  assembly_version: '2.0.0'
+  assembly_version: '2.0.1'
 
 version: '$(nuget_version)+{build}'
 configuration: Release


### PR DESCRIPTION
This addresses #35 (and possibly #33 too).

It *seems* to work for me, but I don't fully understand why. To reproduce, create a behavior in a file, and reference it in a `Behaves_like` field from a context in a different file. Then open the behavior file and add or remove specification fields and observe the changes in the R# unit test explorer and test session windows.

The critical part of this is here:
```c#
_observer.OnUnitTestElementDisposition(UnitTestElementDisposition.NotYetClear(element));
```

which raises dispositions in files that are not currently visible, which seems to fix the problem (I think...).

@citizenmatt any hints on whether this is the right approach?