### PR TITLE
[Bug] Fix working directory for contexts

### DIFF
--- a/Machine.Specifications.ReSharper.Runner.10/TestRunListener.cs
+++ b/Machine.Specifications.ReSharper.Runner.10/TestRunListener.cs
@@ -1,5 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.IO;
+using System.Linq;
 using JetBrains.ReSharper.TaskRunnerFramework;
+using Machine.Specifications.ReSharperRunner.Tasks;
 using Machine.Specifications.Runner.Utility;
 
 namespace Machine.Specifications.ReSharperRunner
@@ -23,6 +26,8 @@ namespace Machine.Specifications.ReSharperRunner
 
         public void OnAssemblyStart(Runner.Utility.AssemblyInfo assemblyInfo)
         {
+            Environment.CurrentDirectory = GetWorkingDirectory(_context.AssemblyTask);
+
             _server.TaskStarting(_context.AssemblyTask);
         }
 
@@ -142,6 +147,11 @@ namespace Machine.Specifications.ReSharperRunner
             var exception = result.Flatten().FirstOrDefault();
 
             return exception != null ? $"{exception.FullTypeName}: {exception.Message}" : string.Empty;
+        }
+
+        private string GetWorkingDirectory(MspecTestAssemblyTask task)
+        {
+            return Path.GetDirectoryName(task.AssemblyLocation);
         }
     }
 }

--- a/Machine.Specifications.ReSharper.Runner.10/TestRunner.cs
+++ b/Machine.Specifications.ReSharper.Runner.10/TestRunner.cs
@@ -26,8 +26,6 @@ namespace Machine.Specifications.ReSharperRunner
                 _taskServer.SetTempFolderPath(environment.ShadowCopyPath);
             }
 
-            Environment.CurrentDirectory = environment.AssemblyFolder;
-
             var appDomainRunner = new AppDomainRunner(listener, runOptions);
 
             try

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Visual Studio 2017
 
 environment:
-  nuget_version: '2.0.1'
+  nuget_version: '2.0.2'
   nuget_prerelease: false
-  assembly_version: '2.0.1'
+  assembly_version: '2.0.2'
 
 version: '$(nuget_version)+{build}'
 configuration: Release


### PR DESCRIPTION
Fixes #39 

I think this works? I'm not sure this fixes issues (if any exist) for running tests outside of the R# runner, (from the console for instance), but I've tested this with netframework and netcore projects.